### PR TITLE
Make course descriptions expandable

### DIFF
--- a/app/assets/javascripts/templates/courses.hbs
+++ b/app/assets/javascripts/templates/courses.hbs
@@ -6,7 +6,10 @@
         <department-code>{{department_code department_id}}</department-code>
         <course-number>{{number}}</course-number>
         <course-credits>{{course_credits this}}</course-credits>
-        <course-description>{{description}}</course-description>
+        {{#description_exists description}}
+            <course-description>{{description}}</course-description>
+            <!-- <button type="button" class="expand&#45;course&#45;description">...</button> -->
+        {{/description_exists}}
       </course-info>
       <sections>
         {{#sections}}

--- a/app/assets/javascripts/views/courses.js
+++ b/app/assets/javascripts/views/courses.js
@@ -28,7 +28,7 @@ Handlebars.registerHelper('closed_status', function (s) {
 });
 
 Handlebars.registerHelper('day_name', function (n) {
-  return new Handlebars.SafeString(['Sun', 'Mon', 'Tue', 'Wed', 'Thr', 'Fri', 'Sat'][n]);
+  return new Handlebars.SafeString(['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][n]);
 });
 
 Handlebars.registerHelper('time_range', function (start, end) {
@@ -42,6 +42,12 @@ Handlebars.registerHelper('time_range', function (start, end) {
   }).join('-'));
 });
 
+Handlebars.registerHelper('description_exists', function(description, options) {
+   if(description.length > 0)
+      return options.fn(this);
+   else
+      return options.inverse(this);
+});
 
 /**
  * Courses view. Displays courses and their sections
@@ -88,7 +94,7 @@ Yacs.views.courses = function (target, data) {
 
   /**
    * When a course is clicked, select all of its open sections if they are not
-   * selected. If all open sections are selected, unselect them all. 
+   * selected. If all open sections are selected, unselect them all.
    */
   target.getElementsByTagName('course').forEach(function (c) {
     Yacs.on('click', c.getElementsByTagName('course-info')[0], function (ci) {
@@ -105,5 +111,15 @@ Yacs.views.courses = function (target, data) {
       c.classList[isSelected ? 'remove' : 'add']('selected');
     });
     if (isCourseSelected(c)) c.classList.add('selected');
+  });
+
+  /**
+   * Expand course descriptions when clicked.
+   */
+  target.getElementsByTagName('course-description').forEach(function(cd) {
+    Yacs.on('click', cd, function(cd_, event_) {
+      cd_.classList.add('expanded');
+      event_.stopPropagation();
+    });
   });
 };

--- a/app/assets/javascripts/views/index.js
+++ b/app/assets/javascripts/views/index.js
@@ -25,10 +25,10 @@ Yacs.views.index = function () {
     var key = event.keyCode;
     if (!(event.ctrlKey || event.metaKey)) {
       if ((key >= 48 && key <= 105) || key == 32) {
-        if (key == 127 && searchbar.value.length <= 1)
-          Yacs.views.departments(content);
+        // normal keys focus the searchbar
         searchbar.focus();
       } else if (key == 13) {
+        // enter searches
         if (searchbar.value) {
           Yacs.models.courses.query({ search: searchbar.value,
                                       show_sections: true,
@@ -37,11 +37,7 @@ Yacs.views.index = function () {
               if (success)
                 Yacs.views.courses(content, data);
           });
-        } else {
-          Yacs.views.departments(content);
         }
-      } else if ((key == 8 || key == 46) && searchbar.value.length <= 1) {
-        Yacs.views.departments(content);
       }
     }
   });

--- a/app/assets/javascripts/views/schedules.js
+++ b/app/assets/javascripts/views/schedules.js
@@ -43,7 +43,9 @@ Yacs.views.schedule = function (target) {
       var courseIds = [];
       var events = [];
       var crns = [];
+      var totalCredits = 0;
       schedule.sections.forEach(function (section) {
+         console.log(section);
         var color = courseIds.indexOf(section.course_id);
         if (color == -1) {
           courseIds.push(section.course_id);
@@ -80,14 +82,14 @@ Yacs.views.schedule = function (target) {
     var data = processSchedules(schedules);
     scheduleData = data.schedules;
     schedule.destroy();
-    schedule = new Schedule(scheduleElement, 
+    schedule = new Schedule(scheduleElement,
       { timeBegin: Math.ceil((data.start) / 60) * 60,
         timeSpan: Math.ceil((data.end - data.start) / 60) * 60 });
     scheduleCountElement.textContent = scheduleData.length;
     if (scheduleData.length > 0) {
-      show(0);
+      showSchedule(0);
     } else {
-      show(-1);
+      showSchedule(-1);
       if (Yacs.user.getSelections().length > 0) {
         scheduleStatusElement.textContent = "No schedules found :( Try removing some courses";
       } else {
@@ -125,14 +127,16 @@ Yacs.views.schedule = function (target) {
    * Show schdule at given index, and display corresponding CRNs.
    * If index is -1, show nil schedule.
    */
-  var show = function (index) {
+  var showSchedule = function (index) {
     if (index == -1) {
       scheduleStatusElement.textContent = "";
       scheduleNumElement.textContent = 0;
     } else {
       schedule.setEvents(scheduleData[index].events)
       scheduleNumElement.textContent = index + 1;
-      scheduleStatusElement.textContent = 'CRNs: ' + scheduleData[index].crns.join(', ');
+      scheduleStatusStr = 'CRNs: ' + scheduleData[index].crns.join(', ')
+      scheduleStatusStr += ' Total Credits: ' + scheduleData[index].totalCredits;
+      scheduleStatusElement.textContent = scheduleStatusStr;
     }
   };
 
@@ -142,7 +146,7 @@ Yacs.views.schedule = function (target) {
   var next = function () {
     if (scheduleData.length > 0) {
       scheduleIndex = (++scheduleIndex < scheduleData.length ? scheduleIndex : 0);
-      show(scheduleIndex);
+      showSchedule(scheduleIndex);
     }
   }
 
@@ -152,7 +156,7 @@ Yacs.views.schedule = function (target) {
   var previous = function () {
     if (scheduleData.length > 0) {
       scheduleIndex = (--scheduleIndex < 0 ? scheduleData.length - 1 : scheduleIndex);
-      show(scheduleIndex);
+      showSchedule(scheduleIndex);
     }
   }
 

--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -11,13 +11,13 @@ course:last-child {
     border: none;
 }
 
-course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed) {
-    background-color: #d57f7f;
-}
-course.selected>course-info:hover ~ sections section.selected {
-    color: #efefef;
-    background-color: #d57f7f;
-}
+/* course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed) { */
+/*     background-color: #d57f7f; */
+/* } */
+/* course.selected>course-info:hover ~ sections section.selected { */
+/*     color: #efefef; */
+/*     background-color: #d57f7f; */
+/* } */
 
 course-name {
     font-size: 130%;
@@ -29,17 +29,42 @@ course department-code {
 course-credits {
     margin-left:0.7em;
 }
+div.description-container {
+   display:block;
+   max-width:100%;
+}
 course-description {
     display:block;
     font-size:87%;
-    text-align: justify;
+    text-align:justify;
     white-space:nowrap;
     overflow-x:hidden;
     text-overflow:ellipsis;
+    /* float:left; */
+    /* max-width:200px; */
+}
+course-description:not(.expanded):hover {
+   color: #993333;
 }
 course-description.expanded {
    white-space: normal;
    overflow-x: visible;
+   text-align: justify;
+}
+button.expand-course-description {
+   background-color: transparent;
+   background-repeat: no-repeat;
+   border: 1px #afafaf solid;
+   border-radius: 5px;
+   color: #afafaf;
+   /* margin: 1px 0; */
+   /* float:right; */
+   /* margin-left:auto; */
+   /* margin-right:0; */
+   /* overflow: hidden; */
+   outline: none;
+   cursor:pointer;
+   display:inline-block;
 }
 section {
     display:block;

--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -29,10 +29,10 @@ course department-code {
 course-credits {
     margin-left:0.7em;
 }
-div.description-container {
-   display:block;
-   max-width:100%;
-}
+/* div.description-container { */
+/*    display:block; */
+/*    max-width:100%; */
+/* } */
 course-description {
     display:block;
     font-size:87%;
@@ -51,21 +51,21 @@ course-description.expanded {
    overflow-x: visible;
    text-align: justify;
 }
-button.expand-course-description {
-   background-color: transparent;
-   background-repeat: no-repeat;
-   border: 1px #afafaf solid;
-   border-radius: 5px;
-   color: #afafaf;
-   /* margin: 1px 0; */
-   /* float:right; */
-   /* margin-left:auto; */
-   /* margin-right:0; */
-   /* overflow: hidden; */
-   outline: none;
-   cursor:pointer;
-   display:inline-block;
-}
+/* button.expand-course-description { */
+/*    background-color: transparent; */
+/*    background-repeat: no-repeat; */
+/*    border: 1px #afafaf solid; */
+/*    border-radius: 5px; */
+/*    color: #afafaf; */
+/*    margin: 1px 0; */
+/*    float:right; */
+/*    margin-left:auto; */
+/*    margin-right:0; */
+/*    overflow: hidden; */
+/*    outline: none; */
+/*    cursor:pointer; */
+/*    display:inline-block; */
+/* } */
 section {
     display:block;
     margin:0px 0px 0px 5px;

--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -33,6 +33,13 @@ course-description {
     display:block;
     font-size:87%;
     text-align: justify;
+    white-space:nowrap;
+    overflow-x:hidden;
+    text-overflow:ellipsis;
+}
+course-description.expanded {
+   white-space: normal;
+   overflow-x: visible;
 }
 section {
     display:block;


### PR DESCRIPTION
This adds a click event to <course-description> elements which will apply the "expanded" class to them and let them be displayed in full.

Rough things left behind at present:
- This stops the event's propagation so as not to select the course when clicking it. This means that the available area to click on a course to select its sections is considerably smaller. This is not that big of a deal given that we are planning on redoing the course selections.
- I have removed the CSS rule that highlights sections when hovering over the course, because hovering over the course description would highlight them but not actually select them on a click.
- A bunch of WIP CSS and the original expand button are left commented out in the source. I am not sure whether they should be removed or just left there for future course list redesigns.
- The course description now has a hover color, but I have not had any feedback on the color. It could be changed; I don't think it looks particularly great.

This CAN be merged along with #134, but it could also possibly wait until a course list redesign comes along. However, I would favor merging it now, since such a redesign is still so vague that there are no issues relating to it.

This closes #90.
