### PR TITLE
Adds unavailable description text to course view.

### DIFF
--- a/app/assets/javascripts/controllers/courses/helpers.js
+++ b/app/assets/javascripts/controllers/courses/helpers.js
@@ -15,7 +15,7 @@ Handlebars.registerHelper('course_credits', function (c) {
 
 Handlebars.registerHelper('formatted_description', function (description) {
   if (description === '') {
-    description = 'description not available...';
+    description = 'Description not available...';
   }
   return new Handlebars.SafeString(description);
 });

--- a/app/assets/javascripts/controllers/courses/helpers.js
+++ b/app/assets/javascripts/controllers/courses/helpers.js
@@ -7,19 +7,16 @@ Handlebars.registerHelper('course_credits', function (c) {
   // render "credit(s)" properly
   if (c.min_credits != c.max_credits) {
     outString = c.min_credits + '-' + c.max_credits + ' credits';
-  }
-  else {
+  } else {
     outString = c.max_credits + ' credit' + (c.max_credits == 1 ? '' : 's');
   }
   return new Handlebars.SafeString(outString);
 });
 
 Handlebars.registerHelper('formatted_description', function (description) {
-  var outString;
+  var outString = description;
   if(description === ''){
     outString = 'description not available...';
-  }else{
-    outString = description;
   }
   return new Handlebars.SafeString(outString);
 });

--- a/app/assets/javascripts/controllers/courses/helpers.js
+++ b/app/assets/javascripts/controllers/courses/helpers.js
@@ -14,11 +14,10 @@ Handlebars.registerHelper('course_credits', function (c) {
 });
 
 Handlebars.registerHelper('formatted_description', function (description) {
-  var outString = description;
-  if(description === ''){
-    outString = 'description not available...';
+  if (description === '') {
+    description = 'description not available...';
   }
-  return new Handlebars.SafeString(outString);
+  return new Handlebars.SafeString(description);
 });
 
 Handlebars.registerHelper('join', function (arr) {

--- a/app/assets/javascripts/controllers/courses/helpers.js
+++ b/app/assets/javascripts/controllers/courses/helpers.js
@@ -14,6 +14,16 @@ Handlebars.registerHelper('course_credits', function (c) {
   return new Handlebars.SafeString(outString);
 });
 
+Handlebars.registerHelper('formatted_description', function (description) {
+  var outString;
+  if(description === ''){
+    outString = 'description not available...';
+  }else{
+    outString = description;
+  }
+  return new Handlebars.SafeString(outString);
+});
+
 Handlebars.registerHelper('join', function (arr) {
   return new Handlebars.SafeString(arr.join(', '));
 });

--- a/app/assets/javascripts/templates/courses/template.hbs
+++ b/app/assets/javascripts/templates/courses/template.hbs
@@ -6,7 +6,7 @@
         <department-code>{{department_code department_id}}</department-code>
         <course-number>{{number}}</course-number>
         <course-credits>{{course_credits this}}</course-credits>
-        <course-description>{{description}}</course-description>
+        <course-description>{{formatted_description description}}</course-description>
       </course-info>
       <sections>
         {{#sections}}


### PR DESCRIPTION
This pull request adds text indication to course descriptions when the description is unavailable. Instead of displaying an empty string, these courses' descriptions will now display "Description not available..." 

Further styling coming soon.

![unavailable description - regular](https://cloud.githubusercontent.com/assets/12902777/20548219/9484f9d2-b0ef-11e6-8873-c58507b747b7.png)
