### PR TITLE
Revert "Schedule links"

### DIFF
--- a/app/assets/javascripts/controllers/schedules/controller.js
+++ b/app/assets/javascripts/controllers/schedules/controller.js
@@ -6,37 +6,6 @@
  * @memberOf Yacs.views
  */
 Yacs.views.schedules = function (target, params) {
-  // before doing anything, determine how to use the route
-  // parameters to choose the section ids to be passed to the
-  // API
-  var schedule_ids = [];
-
-  // check for query parameters
-  if('section_ids' in params) {
-    // if there are query parameters,
-    // use them and ignore current selections
-    schedule_ids = params['section_ids'].split(',');
-
-    // If the cookie doesn't have any selections,
-    // write them into it. The URL will still display the parameters as long as
-    // the route doesn't change.
-    if(Yacs.user.getSelections().length < 1) {
-      Yacs.user.addSelections(schedule_ids);
-    }
-  }
-  else {
-    // if section_ids is not specified in params, use the cookie
-    // to populate the schedule_ids list
-    schedule_ids = Yacs.user.getSelections();
-  }
-
-  //initialize scheduleIndex at 0, unless explicitly specified in the query
-  //parameters
-  var scheduleIndex = 0;
-  if('schedule_index' in params) {
-    scheduleIndex = parseInt(params['schedule_index']);
-  }
-
   Yacs.render(target, 'schedules');
 
   var scheduleElement = target.querySelector('#schedule-container');
@@ -48,9 +17,9 @@ Yacs.views.schedules = function (target, params) {
   var scheduleCountElement = target.querySelector('#schedule-count');
   var scheduleStatusElement = target.querySelector('#schedule-status');
   var downloadICSElement = target.querySelector('#ics-btn');
-  var copyLinkElement = target.querySelector('#link-btn');
   var schedule = new Schedule(scheduleElement);
   var scheduleData = [];
+  var scheduleIndex = 0;
 
   /**
    * Convert military time string to minutes-since-midnight integer form.
@@ -115,13 +84,10 @@ Yacs.views.schedules = function (target, params) {
     schedule.destroy();
     schedule = new Schedule(scheduleElement,
       { timeBegin: Math.ceil((data.start) / 60) * 60,
-        timeSpan: Math.ceil((data.end - data.start) / 60) * 60
-      }
-    );
+        timeSpan: Math.ceil((data.end - data.start) / 60) * 60 });
     scheduleCountElement.textContent = scheduleData.length;
-
     if (scheduleData.length > 0) {
-      showSchedule(scheduleIndex);
+      showSchedule(0);
     } else {
       showSchedule(-1);
       if (Yacs.user.getSelections().length > 0) {
@@ -137,10 +103,8 @@ Yacs.views.schedules = function (target, params) {
    * and update the view to show the new schedules.
    * If no sections are selected, skip the call and show nil schedules.
    */
-  var updateSchedules = function (selections) {
-    if(typeof selections == 'undefined') {
-      selections = Yacs.user.getSelectionsRaw();
-    }
+  var updateSchedules = function () {
+    var selections = Yacs.user.getSelectionsRaw();
     if (selections.length > 0) {
       Yacs.models.schedules.query({ section_ids: selections,
                                     show_periods: true },
@@ -171,27 +135,6 @@ Yacs.views.schedules = function (target, params) {
     periods = scheduleData[scheduleIndex].events;
     vCalendarData = Yacs.vCalendar.createVCalendar(periods);
     Yacs.vCalendar.download(vCalendarData);
-  };
-
-  /**
-   * Generate a link to this set of schedules from current selections
-   * and copy it to the user's clipboard.
-   */
-  var copyScheduleLink = function() {
-    targetUrl = window.location.protocol + '//' +
-      window.location.host +
-      '/#/schedules?section_ids=' + Yacs.user.getSelections().join(',') +
-      '&schedule_index=' + scheduleIndex;
-    // js hack to create and copy from a phantom element
-    var textarea = document.createElement('textarea');
-    textarea.value = targetUrl;
-    document.body.appendChild(textarea);
-    textarea.select();
-    var success = document.execCommand('copy');
-    if(!success) {
-      // maybe add some code here later to show an error message
-    }
-    document.body.removeChild(textarea);
   };
 
   /**
@@ -247,15 +190,9 @@ Yacs.views.schedules = function (target, params) {
     Yacs.user.clearSelections();
   });
 
-  /**
-   * Prompt the creation and download of the schedule ICS when the button is clicked.
+  /* Prompt the creation and download of the schedule ICS when the button is clicked.
    */
   Yacs.on('click', downloadICSElement, getICSDownload);
-
-  /**
-   * Copy a link to this set of schedules to the user's clipboard.
-   */
-  Yacs.on('click', copyLinkElement, copyScheduleLink);
 
   /**
    * Show selected courses / sections on the schedule page. The courses shown
@@ -268,6 +205,5 @@ Yacs.views.schedules = function (target, params) {
   }
 
   Yacs.observe('selection', scheduleElement, updateSchedules);
-  // use section ids extracted from URL parameters at top
-  updateSchedules(schedule_ids);
+  updateSchedules();
 };

--- a/app/assets/javascripts/lib/router.js
+++ b/app/assets/javascripts/lib/router.js
@@ -26,13 +26,7 @@ Yacs.router = new function () {
       var resource = window.location.hash.slice(1).split('?');
       var path = resource[0].length ? resource[0] : '/';
       var params = resource[1] || '';
-      if (routes[path]) {
-        routes[path](queryToHash(params));
-      }
-      // handle case i.e. /schedules/ when only /schedules is defined
-      else if(path.slice(-1) == '/' && routes[path.slice(0,-1)]) {
-        routes[path.slice(0,-1)](queryToHash(params));
-      }
+      if (routes[path]) routes[path](queryToHash(params));
     };
     window.addEventListener('hashchange', onChange, false);
     onChange();

--- a/app/assets/javascripts/templates/schedules/template.hbs
+++ b/app/assets/javascripts/templates/schedules/template.hbs
@@ -8,7 +8,6 @@
       </div>
       <button type="button" id="clear-btn" class="clear-button">Clear</button>
       <button type="button" id="ics-btn" class="clear-button">Download ICS</button>
-      <button type="button" id="link-btn" class="clear-button">Copy Schedule Link</button>
     </div>
     <div id="right">
       <div id="schedule-status"></div>


### PR DESCRIPTION
Reverts YACS-RCOS/yacs#149

There is a bug that was introduced by this PR that breaks selection from the schedules view. Steps to reproduce:

1. Select a course from courses view
2. Navigate to schedules view
3. Observe valid schedule
4. Unselect course from selections view
5. Reselect course from selections view
6. Observe no valid schedules and no network request made.

#149 will be reopened.