### PR TITLE
Hotfix for deselection bug

### DIFF
--- a/app/assets/javascripts/lib/user.js
+++ b/app/assets/javascripts/lib/user.js
@@ -139,8 +139,8 @@ window.Yacs.user = new function () {
       var i = arr.indexOf(sid);
       if (i !== -1) {
         removed = true;
+        arr.splice(i, 1);
       }
-      arr.splice(i, 1);
     });
     setCookie('selections', arr.join(','));
     observable.notify();


### PR DESCRIPTION
Due to an incorrect ESLint change, a bug was introduced that led to additional sections on the end of the current selection list possibly being removed when removeSelections() was called on a group of sections. This fixes that bug.