### PR TITLE
Add day names to the schedule

### DIFF
--- a/vendor/assets/javascripts/schedule/schedule.js
+++ b/vendor/assets/javascripts/schedule/schedule.js
@@ -1,3 +1,16 @@
+/**
+ * Schedule function. Initializes a Schedule object and renders it inside
+ * a provided element. A Schedule represents a weekly schedule.
+ * @constructor
+ * @param {HTMLElement} scheduleContainer - The HTML element in which to render the schedule grid.
+ * @param {Object} options - An object containing any of several fields to determine the time ranges of the schedule.
+ * @param {int} options.daySpan - The number of days to display. Default is 5.
+ * @param {int} options.dayBegin - The first day of the week to show (week is Sunday to Saturday, Sunday = 0). Default is 1 (Monday).
+ * @param {int} options.gridSize - The number of minutes represented by each grid box vertically. Changing this does not change the overall size of the schedule. Default is 60.
+ * @param {int} options.timeSpan - The total nuber of minutes to display. Rounds up to the nearest hour. Default is 720 (12 hours).
+ * @param {int} options.timeBegin - The starting minute of the schedule, in minutes since midnight format. Default is 480 (8 AM).
+ */
+
 window.Schedule = function (scheduleContainer, options) {
   var self = this;
 
@@ -15,20 +28,10 @@ window.Schedule = function (scheduleContainer, options) {
   // var BORDER_COLORS     = ['#b62', '#b44', '#994', '#448', '#499', '#949'];
 
   options = options || {};
-
-  // number of days to be shown
   options.daySpan   = options.daySpan   || 5;
-
-  // first day of the week to be shown (week is Sunday to Saturday, Sunday = 0)
   options.dayBegin  = options.dayBegin  || 1;
-
-  // number of minutes per vertical grid box
   options.gridSize  = options.gridSize  || 60;
-
-  // total number of minutes to display
   options.timeSpan  = Math.ceil((options.timeSpan  || 720) / 60) * 60;
-
-  // starting minute (in minutes since midnight format; default is 480 = 8AM)
   options.timeBegin = Math.ceil((options.timeBegin || 480) / 60) * 60;
 
   var scheduleElement = document.createElement('schedule-view');

--- a/vendor/assets/javascripts/schedule/schedule.js
+++ b/vendor/assets/javascripts/schedule/schedule.js
@@ -7,6 +7,7 @@ window.Schedule = function (scheduleContainer, options) {
   var BORDER_COLORS     = ['#ff2066', '#00aff2', '#ffcb45', '#48da58', '#d373da', '#a48363', '#ff9332'];
   var SELECTED_COLORS   = ['#ff3575', '#19b5f2', '#ffcf56', '#59dc68', '#d57fdd', '#ac8f71', '#ff9c46'];
   // /*                         PINK       BLUE       YELLOW     GREEN      PURPLE     BROWN      ORANGE */
+  var DAY_NAMES         = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
   // var NUM_COLORS        = 6;
   // var TEXT_COLORS       = ['#720', '#722', '#661', '#227', '#166', '#616'];
@@ -14,10 +15,20 @@ window.Schedule = function (scheduleContainer, options) {
   // var BORDER_COLORS     = ['#b62', '#b44', '#994', '#448', '#499', '#949'];
 
   options = options || {};
+
+  // number of days to be shown
   options.daySpan   = options.daySpan   || 5;
+
+  // first day of the week to be shown (week is Sunday to Saturday, Sunday = 0)
   options.dayBegin  = options.dayBegin  || 1;
+
+  // number of minutes per vertical grid box
   options.gridSize  = options.gridSize  || 60;
+
+  // total number of minutes to display
   options.timeSpan  = Math.ceil((options.timeSpan  || 720) / 60) * 60;
+
+  // starting minute (in minutes since midnight format; default is 480 = 8AM)
   options.timeBegin = Math.ceil((options.timeBegin || 480) / 60) * 60;
 
   var scheduleElement = document.createElement('schedule-view');
@@ -42,12 +53,19 @@ window.Schedule = function (scheduleContainer, options) {
     var eventBackground = document.createElement('event-background');
     var colorIndex      = event.colorNum % NUM_COLORS;
 
+    /* This uses smelly hacks to calculate the exact size needed,
+     * which depend on the associated CSS code.
+     * 16px = exact offset to account for day-label at top of column
+     * -5px = eat up 4px of schedule-element left border and 1px of grid-hour right border
+     * -1px = eat up 1px of grid-hour bottom border
+     * Anyone in the future who wants to figure out some way to not have to do these offsets, PLEASE do.
+     */
     eventText.innerHTML                   = event.title.join('<br>');
     eventText.style.color                 = TEXT_COLORS[colorIndex];
-    eventElement.style.top                = timeSize(event.start - options.timeBegin);
+    eventElement.style.top                = 'calc(' + timeSize(event.start - options.timeBegin) + ' + 16px)';
     eventElement.style.left               = daySize(event.day - options.dayBegin);
-    eventElement.style.width              = 'calc(' + daySize(1) + ' - 6px)';
-    eventElement.style.height             = 'calc(' + timeSize(event.end - event.start) + ' - 2px)';
+    eventElement.style.width              = 'calc(' + daySize(1) + ' - 5px)';
+    eventElement.style.height             = 'calc(' + timeSize(event.end - event.start) + ' - 1px)';
     eventElement.style.borderColor        = BORDER_COLORS[colorIndex];
     eventBackground.style.backgroundColor = BACKGROUND_COLORS[colorIndex];
 
@@ -97,6 +115,11 @@ window.Schedule = function (scheduleContainer, options) {
     for (var d = 0; d < options.daySpan; ++d) {
       var dayElement = document.createElement('grid-day');
       dayElement.style.width = daySize(1);
+
+      // add day label to the top of each day column
+      var dayLabel = document.createElement('day-label');
+      dayLabel.textContent = DAY_NAMES[d + options.dayBegin];
+      dayElement.appendChild(dayLabel);
 
       for (var r = 0; r < options.timeSpan / options.gridSize; ++r) {
         var hourElement = document.createElement('grid-hour');

--- a/vendor/assets/stylesheets/schedule/schedule.css
+++ b/vendor/assets/stylesheets/schedule/schedule.css
@@ -32,12 +32,23 @@ grid-day {
   float: left;
 }
 
+day-label {
+  color: #777777;
+  display:block;
+  margin: 0 auto;
+  text-align: center;
+  /* should be the same as grid-hour */
+  border-bottom: 1px solid #e7e7e7;
+  height:16px;
+  max-height:16px;
+  font-variant: small-caps;
+}
+
 grid-hour {
   display: block;
   box-sizing: border-box;
-  opacity: 0.25;
-  border-bottom: 1px solid #999599;
-  border-right: 1px solid #999599;
+  border-bottom: 1px solid #e7e7e7;
+  border-right: 1px solid #e7e7e7;
 }
 
 grid-day:last-child grid-hour {
@@ -66,7 +77,6 @@ event-background {
   height: 100%;
   width: 100%;
   top: 0;
-  z-index: -1;
 }
 
 event-text {


### PR DESCRIPTION
A quick addition to the Schedule library that adds the names of each day above its column on the schedule.

Closes #197.