### PR TITLE
Adds extra validation to conflicts cookie, Fixes course selection behavior

### DIFF
--- a/app/assets/javascripts/controllers/courses/controller.js
+++ b/app/assets/javascripts/controllers/courses/controller.js
@@ -74,8 +74,7 @@ Yacs.views.courses = function (target, params) {
    * in their normal format.
    * Return an object containing the flattened array and the course id map.
    * @param {Object} selections - The selections object returned verbatim from Yacs.user.getSelections().
-   * @return {Object} The selection data converted into an array of 2-element arrays, each with a section
-   * id and its associated course id, and a map of each course ID to its number of selected sections.
+   * @return {Object} The selection data converted into an array of 2-element arrays, each with a section id and its associated course id, and a map of each course ID to its number of selected sections.
    */
   var flattenSelections = function(selections) {
     var selectionsFlat = [];
@@ -161,7 +160,6 @@ Yacs.views.courses = function (target, params) {
 
     // if here, either the conflict array or the flat selections array has been exhausted
     return false;
-
   };
 
   /**

--- a/app/assets/javascripts/controllers/courses/controller.js
+++ b/app/assets/javascripts/controllers/courses/controller.js
@@ -27,11 +27,11 @@ Yacs.views.courses = function (target, params) {
 
     Yacs.on('click', target.querySelectorAll('course-info'), function (courseInfo) {
       var cid = courseInfo.parentElement.dataset.id;
-      if (courseInfo.parentElement.classList.contains('selected')) {
+      if (Yacs.user.courseIsSelected(cid)) {
         Yacs.user.removeCourse(cid);
       }
       else {
-        var sections = courseInfo.parentElement.querySelectorAll('section:not(.closed):not(.conflicts)');
+        var sections = courseInfo.parentElement.querySelectorAll('section:not(.closed)');
 
         // TODO: optimize
         Yacs.user.addMultipleSelections(sections.map(function (section) {
@@ -74,7 +74,8 @@ Yacs.views.courses = function (target, params) {
    * in their normal format.
    * Return an object containing the flattened array and the course id map.
    * @param {Object} selections - The selections object returned verbatim from Yacs.user.getSelections().
-   * @return {Object} The selection data converted into an array of 2-element arrays, each with a section id and its associated course id, and a map of each course ID to its number of selected sections.
+   * @return {Object} The selection data converted into an array of 2-element arrays, each with a section
+   * id and its associated course id, and a map of each course ID to its number of selected sections.
    */
   var flattenSelections = function(selections) {
     var selectionsFlat = [];
@@ -172,24 +173,17 @@ Yacs.views.courses = function (target, params) {
     // actually updated. Actually, why doesn't this already do that?
     var flatObj = flattenSelections(Yacs.user.getSelections());
     target.querySelectorAll('course').forEach(function (course) {
-      var courseSelected = false;
       var sections = course.querySelectorAll('section');
       if (sections.length > 0) {
-        courseSelected = true;
         sections.forEach(function (section) {
           // TODO optimize this next line somehow
           var sectionSelected = Yacs.user.hasSelection(section.dataset.id, course.dataset.id);
           section.classList.toggle('selected', sectionSelected);
-
           var hasConflict = doesConflict(section.dataset.id, flatObj);
           section.classList.toggle('conflicts', hasConflict);
-
-          if (!sectionSelected && !section.classList.contains('closed') && !section.classList.contains('conflicts')) {
-            courseSelected = false;
-          }
         });
       }
-      course.classList.toggle('selected', courseSelected);
+      course.classList.toggle('selected', Yacs.user.courseIsSelected(course.dataset.id));
     });
   };
 

--- a/app/assets/javascripts/controllers/courses/controller.js
+++ b/app/assets/javascripts/controllers/courses/controller.js
@@ -27,11 +27,11 @@ Yacs.views.courses = function (target, params) {
 
     Yacs.on('click', target.querySelectorAll('course-info'), function (courseInfo) {
       var cid = courseInfo.parentElement.dataset.id;
-      if (Yacs.user.courseIsSelected(cid)) {
+      if (courseInfo.parentElement.classList.contains('selected')) {
         Yacs.user.removeCourse(cid);
       }
       else {
-        var sections = courseInfo.parentElement.querySelectorAll('section:not(.closed)');
+        var sections = courseInfo.parentElement.querySelectorAll('section:not(.closed):not(.conflicts)');
 
         // TODO: optimize
         Yacs.user.addMultipleSelections(sections.map(function (section) {
@@ -184,7 +184,7 @@ Yacs.views.courses = function (target, params) {
           var hasConflict = doesConflict(section.dataset.id, flatObj);
           section.classList.toggle('conflicts', hasConflict);
 
-          if (!sectionSelected && !section.classList.contains('closed')) {
+          if (!sectionSelected && !section.classList.contains('closed') && !section.classList.contains('conflicts')) {
             courseSelected = false;
           }
         });

--- a/app/assets/javascripts/lib/user.js
+++ b/app/assets/javascripts/lib/user.js
@@ -61,6 +61,9 @@ Yacs.user = new function () {
     if (selections) {
       try {
         selections = JSON.parse(selections);
+        if (typeof selections !== 'object') {
+          throw 'Invalid Cookie';
+        }
       }
       catch (error) {
         // if parsing the cookie fails, silently discard selections

--- a/app/assets/javascripts/lib/user.js
+++ b/app/assets/javascripts/lib/user.js
@@ -62,7 +62,7 @@ Yacs.user = new function () {
       try {
         selections = JSON.parse(selections);
         if (typeof selections !== 'object') {
-          throw 'Invalid Cookie';
+          throw new Error('Invalid Cookie');
         }
       }
       catch (error) {

--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -11,7 +11,7 @@ course:last-child {
     border: none;
 }
 
-course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed) {
+course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed):not(.conflicts) {
     background-color: #d57f7f;
 }
 course.selected>course-info:hover ~ sections section.selected {

--- a/app/assets/stylesheets/courses.css
+++ b/app/assets/stylesheets/courses.css
@@ -11,7 +11,7 @@ course:last-child {
     border: none;
 }
 
-course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed):not(.conflicts) {
+course:not(.selected)>course-info:hover ~ sections section:not(.selected):not(.closed) {
     background-color: #d57f7f;
 }
 course.selected>course-info:hover ~ sections section.selected {


### PR DESCRIPTION
There was one case where an existing cookie of the old format would get reserialized into a JSON string and cause undefined behavior. This PR adds extra validation that the deserialized cookie is an object and throws an error if it is not, resetting the cookie to an empty object. This will prevent some strange behavior for some users when they first start using the new release.

Additionally, this fixes the course selection / deselection behavior to match what it was before. Unfortunately, in the point-of-truth for course selection has to remain the DOM at this time, as checking the cookie cannot determine if all open, non-conflicting sections of a particular course are selected or not. This PR also removes conflicting sections from the sections to be selected with an entire course just as closed sections have been. It is confusing to have conflicting sections selected so they should not be automatically selected when a course is selected. Also by (in most cases) preventing conflicting sections from being selected, we get some free pruning of the schedule search tree.