### PR TITLE
Remove permanent postgres docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,6 @@ services:
     restart: unless-stopped
     expose:
       - "6379"
-    volumes:
-      - ./data/redis/:/var/lib/redis/data/
 
   nginx:
     build: ./nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     restart: unless-stopped
     expose:
       - "5432"
-    volumes:
-      - ./data/postgres:/var/lib/postgresql/data
 
   redis:
     image: redis


### PR DESCRIPTION
This removes this volume, since having it be persistent was causing some really weird issues with random database I/O errors and crashes. We'd like to get this in before the impending release.