### PR TITLE
Fix bin scripts on macOS

### DIFF
--- a/bin/yacs-assets
+++ b/bin/yacs-assets
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose run web rake assets:precompile && rm -f public/index.html
 chmod -f a+r public/* || :

--- a/bin/yacs-bash
+++ b/bin/yacs-bash
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose run web bash

--- a/bin/yacs-build
+++ b/bin/yacs-build
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose build

--- a/bin/yacs-dbsetup
+++ b/bin/yacs-dbsetup
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 mkdir -p data/potsgres
 docker-compose run web bundle exec rake db:create db:migrate

--- a/bin/yacs-generate-cert
+++ b/bin/yacs-generate-cert
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../nginx/ssl
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../nginx/ssl
 
 openssl req -x509 -nodes -days 730 -newkey rsa:2048 -keyout privkey.pem -out cert.pem -subj '/CN=localhost'
 

--- a/bin/yacs-run
+++ b/bin/yacs-run
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose run web $@

--- a/bin/yacs-start
+++ b/bin/yacs-start
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose up

--- a/bin/yacs-startd
+++ b/bin/yacs-startd
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose up -d

--- a/bin/yacs-stop
+++ b/bin/yacs-stop
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 docker-compose stop

--- a/bin/yacs-test
+++ b/bin/yacs-test
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 RAILS_ENV=test docker-compose run web bundle exec rake

--- a/bin/yacs-update
+++ b/bin/yacs-update
@@ -1,4 +1,4 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 git pull origin

--- a/bin/yacs-update-deploy
+++ b/bin/yacs-update-deploy
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd $(dirname `readlink -f "$0"`)/../
+cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)/../
 
 bin/yacs-update
 bin/yacs-build

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -130,10 +130,12 @@ http {
     keepalive_disable msie6;
     reset_timedout_connection on;
 
+    # If the buffer sizes are too low, then Nginx will write to a temporary file on disk instead of writing to memory.
+
     client_body_buffer_size 10K;
-    client_header_buffer_size 1k;
+    client_header_buffer_size 2k;
     client_max_body_size 8m;
-    large_client_header_buffers 2 1k;
+    large_client_header_buffers 2 2k;
 
     server_tokens off;
 


### PR DESCRIPTION
Use cd, pwd & dirname instead of GNU readlink in scripts for compatibility with macOS and other *nix systems with BSD commands.