### PR TITLE
Limit the maximum number of schedules to 1000

### DIFF
--- a/lib/scheduler.rb
+++ b/lib/scheduler.rb
@@ -7,7 +7,7 @@ class Scheduler
   end
 
   def self.search(params, schedules, schedule=[])
-    return if params.size == 0
+    return if params.size == 0 or schedules.size > 999
     if schedule.size < params.size
       params[schedule.size].each do |new_section|
         conflict = false


### PR DESCRIPTION
Some combinations of courses / sections will result in many thousands of schedules being generated. This is problematic as it causes very slow running requests. Limiting the number of schedules to 1000 is an acceptable workaround for this for the time being. Ultimately, pagination would be a better solution but that isn't in our roadmap right now.