### PR TITLE
Updated page title to 2018

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>YACS 2017</title>
+  <title>YACS 2018</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
The title of every page on YACS currently says 2017 so I thought I would make a pull request to fix this. 2017 is also what google says when you google YACS and this would fix that as well.

Also I am an upcoming RPI freshman majoring in CS