### PR TITLE
Hide content overflow

### DIFF
--- a/web/src/app/app.component.html
+++ b/web/src/app/app.component.html
@@ -6,7 +6,7 @@
   </button> 
   <sidebar [hidden]="showingSidebar"></sidebar>
   <!-- if there is a notice content will move down -->
-	<div id="content" class="w-100">
+	<div id="content">
 	  <router-outlet></router-outlet>
 	</div>
 </div>

--- a/web/src/app/app.component.scss
+++ b/web/src/app/app.component.scss
@@ -8,6 +8,11 @@
 //   white-space: nowrap;
 // }
 
+#content {
+  margin: auto;
+  overflow: hidden;
+}
+
 img#loading {
   position:absolute;
   top: 50%;


### PR DESCRIPTION
This change resolves #371 by hiding the main content when it overflows, i.e. when the sidebar is expanded on a smaller viewport. I think this is a nice solution becuase it still shows as much of the sidebar as possible on medium sized viewports or in landscape mode.

![image](https://user-images.githubusercontent.com/787225/52527486-30af7600-2c97-11e9-98d9-fb78e4cbb77d.png)
