### PR TITLE
Redesign the listing component to use a table with auto merging cells

### DIFF
--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -4,35 +4,43 @@
 	  	<div class="indicator h-100" [class.indicator-selected]="isCourseSelected()" [class.indicator-unselected]="!isCourseSelected()" [class.indicator-hover]="hovered && !isCourseSelected()" [class.indicator-selected-hover]="hovered && isCourseSelected()"></div>
 	  </div>
 	  <div class="w-100 h-100 course-content position-relative min-height">
-			<table (click)="clickCourse()" class="w-100">
-		  	<tr>
-		    	<div class="course-name">{{listing.longname}}
-					</div>
-		  	</tr>
-	  	  <tr>
-	  	  	<div class= "course-details">{{listing.course.subject.shortname}}   {{listing.course.shortname}}</div>
-	      </tr>
-		    <tr >
-		    	<div class="course-details">{{creditRange}}</div>
-		    </tr>
-				<tr>
-					<div *ngIf="getSectionConflictCount() === 0 && getSectionClosedCount() === 0; else elseContent" class="closed-conflict null">&nbsp;</div>
-					<ng-template #elseContent>
-						<div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are conflicting">Conflicting Sections</div>
-						<div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are conflicting">Conflicting Sections</div>
-						<div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are closed">Full Sections</div>
-						<div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are closed">Full Sections</div>
-					</ng-template>
-				</tr>
-			</table>
+		  <table (click)="clickCourse()" class="w-100 table-margin">
+			  <tr>
+				  <!--Course title-->
+				  <td colspan="2"><div class="course-name">{{listing.longname}}</div></td>
+			  </tr>
+			  <tr class="course-info align">
+				  <td class="blocked-tags course-info">
+					  <div class= "course-details">{{listing.course.subject.shortname}}   {{listing.course.shortname}}</div>
+				  </td>
+				  <td [rowSpan]="showingDescription ? 3 : 2">
+					  <div *ngIf="showDescription" [class.overflow-hide]="!showingDescription" (click)="descriptionClick($event)"
+						   [class.showDescription]="showingDescription" [class.hideDescription]="!showingDescription"
+						   [class.selectedDescription]="isCourseSelected()">{{listing.description}}</div>
+				  </td>
+			  </tr>
+			  <tr class="align">
+				  <td class="blocked-tags course-info">
+					  <div class="course-details">{{creditRange}}</div>
+				  </td>
+			  </tr>
+			  <tr [class.align]="showingDescription">
+				  <td [colSpan]="showingDescription ? 1 : 2">
+					  <div *ngIf="getSectionConflictCount() === 0 && getSectionClosedCount() === 0; else elseContent" class="closed-conflict null">&nbsp;</div>
+					  <ng-template #elseContent>
+						  <div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are conflicting">Conflicting Sections</div>
+						  <div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are conflicting">Conflicting Sections</div>
+						  <div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are closed">Full Sections</div>
+						  <div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are closed">Full Sections</div>
+					  </ng-template>
+				  </td>
+			  </tr>
+		  </table>
 			<span *ngIf="showDescriptionTooltip" class="description-tooltip position-absolute" [placement]="['right','bottom','left','top','auto']" [ngbPopover]="tooltipDescription" container="body" triggers="mouseenter:mouseleave">
 				<img src="assets/images/info.svg" />
 			</span>
 			<span *ngIf="showRemoveButton" (click)="removeButtonClick()" class="remove-button position-absolute"  [placement]="['right','bottom','left','top','auto']" ngbPopover="Click on this button to remove class from sidebar" container="body" triggers="mouseenter:mouseleave">
 				<img src="assets/images/remove.svg" />
-			</span>
-			<span (click)="descriptionClick()" *ngIf="!showDescriptionTooltip" class="course-description" [class.hideDescription]="!showingDescription" [class.showDescription]="showingDescription" [class.selectedDescription]="isCourseSelected()">
-				{{listing.description}}
 			</span>
 			<div class="menu position-absolute" (click)="showingMenu=!showingMenu">
 				<div class = "arrow-container down-arrow" *ngIf="!showingMenu">

--- a/web/src/app/listing/component.scss
+++ b/web/src/app/listing/component.scss
@@ -134,7 +134,6 @@ i {
 }
 
 .course-name {
-  margin-top: 10px;
   font-size: 100%;
   font-weight: 600;
 }
@@ -162,18 +161,11 @@ i {
 }
 
 .hideDescription {
-  display:flex;
   font-size:95%;
   text-align: justify;
   color: #969696;
-  margin-top: -4.6em;
-  margin-left: 8em;
   margin-right: 2em;
   line-height: 1.7em;
-  overflow: hidden;
-  height: 3.5em;
-  position: relative;
-  z-index: 10;
 }
 
 .hideDescription:hover {
@@ -181,19 +173,16 @@ i {
   color: black;
 }
 
+.overflow-hide {
+  overflow: hidden;
+  height: 3.4em;
+}
+
 .showDescription {
-  display:flex;
   font-size:95%;
   text-align: justify;
-  margin-top: -3.6em;
-  margin-left: 8em;
   margin-right: 2em;
   line-height: 1.7em;
-  bottom: 1em;
-  height: auto;
-  min-height: 3.5em;
-  position: relative;
-  z-index: 10;
 }
 
 .showDescription:hover {
@@ -259,6 +248,10 @@ section.closed, section.closed:hover {
   background: #969696;
 }
 
+.table-margin {
+  margin-bottom: 1em;
+}
+
 .zero-margins {
   padding:0 !important;
   margin:0 !important;
@@ -305,6 +298,18 @@ table {
   padding-right: 8px;
   margin-top: 5px;
   margin-right: 10px
+}
+
+.blocked-tags {
+  width: 145px;
+}
+
+.course-info {
+  height: 1em;
+}
+
+tr.align {
+  vertical-align: top;
 }
 
 .some {

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -69,7 +69,8 @@ export class ListingComponent implements OnInit{
     return this.conflictsService.doesConflict(section);
   }
 
-  public descriptionClick (): void {
+  public descriptionClick (event): void {
+    event.stopPropagation();
     // this.selectionService.toggleCourse(this.listing);
     this.showingDescription= !(this.showingDescription);
   }


### PR DESCRIPTION
Addressing #446, this redesigns the listing component to not overlap text and course tags.
The course tags now move into the column space on the left created by expanding the description.

There are some caveats, namely the position of the credits indicator slightly moves upon expand, but due to the more critical nature of this issue (@Malorn44 wanted to show it off tomorrow at accepted students day), I wasn't able to get a fix for this just yet. Furthermore, the margin at the top of each listing has shrunk, which may or may not be desired (CSS pls).

Images:

Description not expanded:
![image](https://user-images.githubusercontent.com/1103450/56071567-5c191480-5d5d-11e9-8974-51fcb9cfdfba.png)


Expanded:
![image](https://user-images.githubusercontent.com/1103450/56071576-69ce9a00-5d5d-11e9-9fe8-fa9c0f95155c.png)

Sidebar (mostly unchanged):
![image](https://user-images.githubusercontent.com/1103450/56071580-73580200-5d5d-11e9-9de7-4882a9488ef8.png)

Mobile:
Collapsed:
![image](https://user-images.githubusercontent.com/1103450/56071689-e792a580-5d5d-11e9-9487-f2b595c35a67.png)
Expanded:
![image](https://user-images.githubusercontent.com/1103450/56071692-f416fe00-5d5d-11e9-9750-afc3e2370288.png)
Sidebar:
![image](https://user-images.githubusercontent.com/1103450/56071723-232d6f80-5d5e-11e9-8036-7b030256dc6b.png)
