### PR TITLE
Fixed Issue #452 and #421

### DIFF
--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -42,7 +42,7 @@
 			<span *ngIf="showRemoveButton" (click)="removeButtonClick()" class="remove-button position-absolute"  [placement]="['right','bottom','left','top','auto']" ngbPopover="Click on this button to remove class from sidebar" container="body" triggers="mouseenter:mouseleave">
 				<img src="assets/images/remove.svg" />
 			</span>
-			<div class="menu position-absolute" (click)="showingMenu=!showingMenu">
+			<div class="menu position-absolute" (click)="showingMenu=!showingMenu" (click)="showingDescription=!showingDescription">
 				<div class = "arrow-container down-arrow" *ngIf="!showingMenu">
 					<i class="arrow down"></i>
 				</div>

--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -14,7 +14,7 @@
 					  <div class= "course-details">{{listing.course.subject.shortname}}   {{listing.course.shortname}}</div>
 				  </td>
 				  <td [rowSpan]="showingDescription ? 3 : 2">
-					  <div *ngIf="showDescription" [class.overflow-hide]="!showingDescription" (click)="descriptionClick($event)"
+					  <div *ngIf="showDescription" [class.overflow-hide]="!showingDescription" (mousemove)="mouseMoveFunc()" (mouseup)="descriptionClick($event)" (mousedown)="mouseDownFunc()"  (mousemove)="mouseMoveFunc()"
 						   [class.showDescription]="showingDescription" [class.hideDescription]="!showingDescription"
 						   [class.selectedDescription]="isCourseSelected()">{{listing.description}}</div>
 				  </td>

--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -42,7 +42,7 @@
 			<span *ngIf="showRemoveButton" (click)="removeButtonClick()" class="remove-button position-absolute"  [placement]="['right','bottom','left','top','auto']" ngbPopover="Click on this button to remove class from sidebar" container="body" triggers="mouseenter:mouseleave">
 				<img src="assets/images/remove.svg" />
 			</span>
-			<div class="menu position-absolute" (click)="showingMenu=!showingMenu" (click)="showingDescription=!showingDescription">
+			<div class="menu position-absolute" (click)="expandDescripAndListings()">
 				<div class = "arrow-container down-arrow" *ngIf="!showingMenu">
 					<i class="arrow down"></i>
 				</div>

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -28,6 +28,9 @@ export class ListingComponent implements OnInit{
   public showingDescription;
   public hovered;
 
+  public mouseMove: boolean = false;
+  public mouseDown: boolean = false; 
+
   ngOnInit () {
     this.showingMenu = false;
     this.showingDescription = false;
@@ -69,14 +72,27 @@ export class ListingComponent implements OnInit{
     return this.conflictsService.doesConflict(section);
   }
 
-  public descriptionClick (event): void {
-    event.stopPropagation();
-    if ( getSelection() == "" ) {
-      this.clickCourse();
+  public mouseDownFunc (): void { 
+    this.mouseDown = true;
+  }
+
+  public mouseMoveFunc (): void { 
+    if (this.mouseDown) {
+      this.mouseMove = true;
     }
+  }
+
+  public descriptionClick (event): void { 
+    event.stopPropagation();
+    if (this.mouseMove) {
+      this.selectionService.toggleCourse(this.listing);
+    } 
+    
+    this.mouseMove = false;
+    this.mouseDown = false;
+
     // this.selectionService.toggleCourse(this.listing);
     // this.showingDescription= !(this.showingDescription);
-
   }
 
   public get tooltipDescription (): string {

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -90,9 +90,6 @@ export class ListingComponent implements OnInit{
     
     this.mouseMove = false;
     this.mouseDown = false;
-
-    // this.selectionService.toggleCourse(this.listing);
-    // this.showingDescription= !(this.showingDescription);
   }
 
   public get tooltipDescription (): string {

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -71,9 +71,12 @@ export class ListingComponent implements OnInit{
 
   public descriptionClick (event): void {
     event.stopPropagation();
+    if ( getSelection() == "" ) {
+      this.selectionService.toggleCourse(this.listing);
+    }
     // this.selectionService.toggleCourse(this.listing);
-    this.showingDescription= !(this.showingDescription);
-    this.showingMenu = !this.showingMenu;
+    // this.showingDescription= !(this.showingDescription);
+
   }
 
   public get tooltipDescription (): string {
@@ -106,4 +109,10 @@ export class ListingComponent implements OnInit{
     this.sidebarService.removeListing(this.listing);
     this.selectionService.removeListing(this.listing);
   }
+
+  public expandDescripAndListings (): void {
+    this.showingDescription = !this.showingDescription;
+    this.showingMenu = !this.showingMenu;
+  }
+  
 }

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -73,6 +73,7 @@ export class ListingComponent implements OnInit{
     event.stopPropagation();
     // this.selectionService.toggleCourse(this.listing);
     this.showingDescription= !(this.showingDescription);
+    this.showingMenu = !this.showingMenu;
   }
 
   public get tooltipDescription (): string {

--- a/web/src/app/listing/component.ts
+++ b/web/src/app/listing/component.ts
@@ -72,7 +72,7 @@ export class ListingComponent implements OnInit{
   public descriptionClick (event): void {
     event.stopPropagation();
     if ( getSelection() == "" ) {
-      this.selectionService.toggleCourse(this.listing);
+      this.clickCourse();
     }
     // this.selectionService.toggleCourse(this.listing);
     // this.showingDescription= !(this.showingDescription);

--- a/web/src/app/listing/section/component.html
+++ b/web/src/app/listing/section/component.html
@@ -5,7 +5,7 @@
       <div>
         <span *ngIf="doesConflict()" placement="top" triggers="mouseenter:mouseleave" title="Section Conflicts"><img class="conflict-img" src="assets/images/red_exclamation.svg" /></span>
         <span class="section-crn">{{section.crn}}</span>
-        <span class="section-instructors">{{ section.instructors.join(', ') }}</span>
+        <span class="section-instructors"> {{ section.instructors.join(', ') }}</span>
         <div class="section-seats">
           {{ section.seats - section.seatsTaken }}
           <span>/{{ section.seats }} seats</span>

--- a/web/src/app/listing/section/component.html
+++ b/web/src/app/listing/section/component.html
@@ -4,7 +4,7 @@
     <div class="col-2 align-center section-details">
       <div>
         <span *ngIf="doesConflict()" placement="top" triggers="mouseenter:mouseleave" title="Section Conflicts"><img class="conflict-img" src="assets/images/red_exclamation.svg" /></span>
-        <span class="section-crn">{{section.crn}}</span>
+        <span class="section-crn"> {{section.crn}}</span>
         <span class="section-instructors"> {{ section.instructors.join(', ') }}</span>
         <div class="section-seats">
           {{ section.seats - section.seatsTaken }}
@@ -16,7 +16,7 @@
       <table class = "section-periods">
         <tr *ngFor="let week of periods">
           <span *ngFor="let period of week; let i = index">
-            <td class = "period-time">
+            <td [ngClass]="{'period-time-conflict':doesConflict()===true, 'period-time-no-conflict':doesConflict()===false}">
               <div class = "col-12">
                 <div class="row">
                   <span *ngIf="period">{{ getHours(period) }}</span>

--- a/web/src/app/listing/section/component.scss
+++ b/web/src/app/listing/section/component.scss
@@ -36,13 +36,24 @@
     white-space: nowrap;
 }
 
-.period-time {
+.period-time-conflict {
     font-size: 90%;
     width: 6em;
+    color: rgb(112, 105, 105);
+    font-weight: 100;
 }
-.period-day {
+
+.period-time-no-conflict {
+    font-size: 90%;
+    width: 6em;
+    color: #000;
     font-weight: 400;
 }
+
+.period-day {
+    font-weight: 100;
+}
+
 
 div.conflict-note {
     margin-left:0.4em;


### PR DESCRIPTION
Expanding the descriptions also expands the course listings. Expanding the course listings also expands the descriptions. Added a space between CRNs and professor names.

Edit: Darkened the font of class times, CRNS, instructors and seat info from classes that are available. Rows that are conflicting still have lighter text.

Picture of updated text: https://imgur.com/0zMjNY3
