### PR TITLE
Added feature for arrow keys to toggle schedule

### DIFF
--- a/web/src/app/schedule-view/component.ts
+++ b/web/src/app/schedule-view/component.ts
@@ -24,8 +24,6 @@ export class ScheduleViewComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @HostListener('window:keyup', ['$event'])
   keyEvent(event: KeyboardEvent) {
-    console.log(event);
-
     if(event.keyCode === KEY_CODE.RIGHT_ARROW) {
       this.scheduleSet.incrementActiveSchedule();
     }

--- a/web/src/app/schedule-view/component.ts
+++ b/web/src/app/schedule-view/component.ts
@@ -7,6 +7,12 @@ import { ScheduleComponent } from '../schedule-view/schedule/component';
 // import 'rxjs/Rx';
 import {Subject, Subscription} from 'rxjs/Rx';
 import * as domtoimage  from 'dom-to-image';
+import { Component, HostListener } from '@angular/core';
+
+export enum KEY_CODE {
+  RIGHT_ARROW = 39,
+  LEFT_ARROW = 37
+}
 
 @Component({
   selector: 'schedule-view',
@@ -15,6 +21,20 @@ import * as domtoimage  from 'dom-to-image';
 })
 
 export class ScheduleViewComponent implements OnInit, OnDestroy, AfterViewInit {
+
+  @HostListener('window:keyup', ['$event'])
+  keyEvent(event: KeyboardEvent) {
+    console.log(event);
+
+    if(event.keyCode === KEY_CODE.RIGHT_ARROW) {
+      this.scheduleSet.incrementActiveSchedule();
+    }
+
+    if(event.keyCode === KEY_CODE.LEFT_ARROW) {
+      this.scheduleSet.decrementActiveSchedule();
+    }
+  }
+
   @ViewChildren(ScheduleComponent)
   public ScheduleList: QueryList<ScheduleComponent>
 


### PR DESCRIPTION
In YACS 0.9 there was a feature that allowed users to toggle through the schedule options using their keyboard arrows, so I added that feature for YACS 0.12, using the API HostListener. This was issue #459