### PR TITLE
changes background color for course tag tooltip #461

### DIFF
--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -28,10 +28,10 @@
 				  <td [colSpan]="showingDescription ? 1 : 2">
 					  <div *ngIf="getSectionConflictCount() === 0 && getSectionClosedCount() === 0; else elseContent" class="closed-conflict null">&nbsp;</div>
 					  <ng-template #elseContent>
-						  <div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are conflicting">Conflicting Sections</div>
-						  <div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are conflicting">Conflicting Sections</div>
-						  <div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are closed">Full Sections</div>
-						  <div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are closed">Full Sections</div>
+						  <div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbPopover="Some sections are conflicting" container="body" triggers="mouseenter:mouseleave">Conflicting Sections</div>
+						  <div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbPopover="All sections are conflicting" container="body" triggers="mouseenter:mouseleave">Conflicting Sections</div>
+						  <div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbPopover="Some sections are closed" container="body" triggers="mouseenter:mouseleave">Full Sections</div>
+						  <div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbPopover="All sections are closed" container="body" triggers="mouseenter:mouseleave">Full Sections</div>
 					  </ng-template>
 				  </td>
 			  </tr>


### PR DESCRIPTION
I updated the course tags to use ngbPopover like all the other tooltips on the website. Before and after pictures included.

Before:
![screenshot-2019-06-21-15:03:42](https://user-images.githubusercontent.com/11843425/59945748-8c082680-9436-11e9-97c4-94902d9a8206.png)

After:
![screenshot-2019-06-21-15:03:05](https://user-images.githubusercontent.com/11843425/59945747-8b6f9000-9436-11e9-85fb-c200a5045e99.png)
