### PR TITLE
Update web docker config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 
 # dependencies
 **/node_modules
+**/npm-cache
 
 # IDEs and editors
 /.idea

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -38,7 +38,8 @@ services:
       - "4200:4200"
     volumes:
       - "./web/src:/usr/src/app/src"
-    command: "ng build --watch"
+      - "./web/npm-cache:/root/.npm"
+    command: "npm run-script docker-install-build"
 
   malg:
     build: ./malg

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 dist-web
+npm-cache

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,11 +6,12 @@ RUN mkdir -p $APP_DIR/bin
 RUN mkdir -p $APP_DIR/src
 WORKDIR $APP_DIR
 
-RUN npm install -g @angular/cli@6.1.3 --silent --depth 1
-COPY package.json $APP_DIR
-RUN npm install --silent --depth 0
+# this is the NPM cache
+VOLUME /root/.npm
 
-COPY angular.json karma.conf.js protractor.conf.js tsconfig.json tslint.json $APP_DIR
+RUN npm install -g @angular/cli@6.1.3 --depth 1
+
+COPY package.json angular.json karma.conf.js protractor.conf.js tsconfig.json tslint.json $APP_DIR
 COPY ./src $APP_DIR
 
 VOLUME /usr/src/app/dist-web

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "docker-install-build": "npm install && ng build --watch"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
An efficiency improvement to the Docker build of the web service. A directory web/npm-cache is used to store the npm cache in the container (via. a volume). Instead of installing packages during build-time, the packages are installed during the running of the container, but the npm-cache volume makes this fast. Once a package is downloaded, it never has to be re-downloaded, even if package.json is changed.

I basically followed the instructions of this website:
https://itnext.io/npm-install-with-cache-in-docker-4bb85283fa12