### PR TITLE
Fixed course title overflow and made course expansion button bigger.

### DIFF
--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -1,4 +1,4 @@
-<div class = "course" [class.fixed-height]="!showingMenu && !showingDescription" (mouseenter)="hovered=true" (mouseleave) = "hovered=false">
+<div class = "course" (mouseenter)="hovered=true" (mouseleave) = "hovered=false">
 	<div class="row flex-nowrap h-100 min-height">
 	  <div class="indicator-container" (click)="clickCourse()">
 	  	<div class="indicator h-100" [class.indicator-selected]="isCourseSelected()" [class.indicator-unselected]="!isCourseSelected()" [class.indicator-hover]="hovered && !isCourseSelected()" [class.indicator-selected-hover]="hovered && isCourseSelected()"></div>

--- a/web/src/app/listing/component.scss
+++ b/web/src/app/listing/component.scss
@@ -1,7 +1,7 @@
 @import "../../_vars.scss";
 
 .course {
-  padding: 0;
+  padding: 0em;
   box-shadow: 2px 2px 5px 2px #efefef;
   height: 100%;
 }
@@ -38,16 +38,15 @@
 }
 
 .description-tooltip {
-	top: 10px;
-	right: 27px;
+	bottom: 67px;
+	right: 29px;
   width: 24px;
   height: 24px;
 }
 
 .remove-button {
-  top: 40px;
-  right: 27px;
-
+  bottom: 39px;
+  right: 29px;
   width: 24px;
   height: 24px;
 }
@@ -98,13 +97,13 @@
 
 i {
     border: solid black;
-    border-width: 0 3px 3px 0;
+    border-width: 0 5px 5px 0;
     display: inline-block;
     padding: 3px;
 }
 
 .arrow {
-    margin-left: 1em;
+  margin-left: 0em;
 }
 
 .up {
@@ -118,8 +117,10 @@ i {
 }
 
 .arrow-container {
-  padding-left: 1em;
+  padding-left: .4em;
+  padding-right: .1em;
   height: 1.5em;
+  width: 1.1em;
 }
 
 .down-arrow:hover {


### PR DESCRIPTION
Fixed overflow when course title took up two lines in the sidebar. Moved info and delete buttons down to avoid overlapping with title. Made expand button bolder. Fixed #465 
![sidebar-overflow-fixes-7-16](https://user-images.githubusercontent.com/49923986/61318030-20fe0580-a7d2-11e9-84d9-79364db787c3.png)
![button-fixes-7-16](https://user-images.githubusercontent.com/49923986/61318038-24918c80-a7d2-11e9-93c8-7b0913d7bf48.png)

