### PR TITLE
Expand course block/lower opacities

### DIFF
--- a/web/src/app/listing/component.html
+++ b/web/src/app/listing/component.html
@@ -28,10 +28,10 @@
 				  <td [colSpan]="showingDescription ? 1 : 2">
 					  <div *ngIf="getSectionConflictCount() === 0 && getSectionClosedCount() === 0; else elseContent" class="closed-conflict null">&nbsp;</div>
 					  <ng-template #elseContent>
-						  <div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are conflicting">Conflicting Sections</div>
-						  <div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are conflicting">Conflicting Sections</div>
-						  <div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbTooltip="Some sections are closed">Full Sections</div>
-						  <div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbTooltip="All sections are closed">Full Sections</div>
+						  <div *ngIf="getSectionConflictCount() < listing.sections.length && getSectionConflictCount() != 0" class="closed-conflict some" placement="top" ngbPopover="Some sections are conflicting" container="body" triggers="mouseenter:mouseleave">Conflicting Sections</div>
+						  <div *ngIf="getSectionConflictCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbPopover="All sections are conflicting" container="body" triggers="mouseenter:mouseleave">Conflicting Sections</div>
+						  <div *ngIf="getSectionClosedCount() < listing.sections.length && getSectionClosedCount() != 0" class="closed-conflict some" placement="top" ngbPopover="Some sections are closed" container="body" triggers="mouseenter:mouseleave">Full Sections</div>
+						  <div *ngIf="getSectionClosedCount() === listing.sections.length" class="closed-conflict all" placement="top" ngbPopover="All sections are closed" container="body" triggers="mouseenter:mouseleave">Full Sections</div>
 					  </ng-template>
 				  </td>
 			  </tr>

--- a/web/src/app/schedule-view/component.ts
+++ b/web/src/app/schedule-view/component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewInit, ViewChildren, QueryList, Input } from '@angular/core';
+import { Component, OnInit, OnDestroy, AfterViewInit, ViewChildren, QueryList, Input, HostListener } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 import { Schedule } from 'yacs-api-client';
 import { ScheduleSet } from '../models/schedule-set';
@@ -8,6 +8,12 @@ import { ScheduleComponent } from '../schedule-view/schedule/component';
 import {Subject, Subscription} from 'rxjs/Rx';
 import * as domtoimage  from 'dom-to-image';
 
+
+export enum KEY_CODE {
+  RIGHT_ARROW = 39,
+  LEFT_ARROW = 37
+}
+
 @Component({
   selector: 'schedule-view',
   templateUrl: './component.html',
@@ -15,6 +21,18 @@ import * as domtoimage  from 'dom-to-image';
 })
 
 export class ScheduleViewComponent implements OnInit, OnDestroy, AfterViewInit {
+
+  @HostListener('window:keyup', ['$event'])
+  keyEvent(event: KeyboardEvent) {
+    if(event.keyCode === KEY_CODE.RIGHT_ARROW) {
+      this.scheduleSet.incrementActiveSchedule();
+    }
+
+    if(event.keyCode === KEY_CODE.LEFT_ARROW) {
+      this.scheduleSet.decrementActiveSchedule();
+    }
+  }
+
   @ViewChildren(ScheduleComponent)
   public ScheduleList: QueryList<ScheduleComponent>
 

--- a/web/src/app/schedule-view/schedule/component.html
+++ b/web/src/app/schedule-view/schedule/component.html
@@ -1,4 +1,4 @@
-<div class="schedule" [style.height.px] = "totalHeight" #mySchedule>
+<div class="schedule" [style.height.px] = "totalHeight" #mySchedule (mouseleave)="mouseLeft()">
   <div class="schedule-legend">
     <div class="hour-label" [style.height.%] = "hourHeight" *ngFor="let hour of hours; let i = index">
       <div *ngIf="(i != 0)">{{ hour }}</div>
@@ -9,18 +9,23 @@
     <div class="grid-day"  [style.width.%] = "dayWidth" *ngFor="let day of days">
       <div class="day-label">{{ day.longname }}</div>
       <ng-container >
-          <schedule-event *ngFor="let period of periodsOnDay(day)"
+        <div *ngFor="let period of periodsOnDay(day)">
+          <schedule-event (mouseenter)="mouseEnter(period)" #schedule_event
             [style.margin-top.px] = "eventPosition(period)"
             [style.backgroundColor] = "getBackgroundColor(period)"
             [style.borderColor] = "getBorderColor(period)"
             [style.color] = "getTextColor(period)"
+            [style.z-index] = "setZIndex(period)"
+            [style.opacity] = "lowerOpacity(period)"
             [normalHeight] = "eventHeight(period)"
             [period] = "period">
           </schedule-event>
-        <div class="grid-hour" *ngFor="let hour of hours"
+        </div>
+        <div class="grid-hour" *ngFor="let hour of hours" (mouseenter)="mouseLeft()"
           [style.height.%] = "hourHeight" >
         </div>
       </ng-container>
     </div>
+    <div class="right-barrier" (mouseenter)="mouseLeft()"></div>
   </div>
 </div>

--- a/web/src/app/schedule-view/schedule/component.scss
+++ b/web/src/app/schedule-view/schedule/component.scss
@@ -7,13 +7,13 @@
 
 .hour-label{
   color: #777777;
-  font-size: 0.5em;
+  font-size: 0.6em; // Changed
   text-align: right;
   font-variant: small-caps;
 }
 
 .schedule-grid {
-  position: absolute;
+  position: relative;
   width: 100%;
   height: 100%;
   left: 2.5em;
@@ -43,9 +43,8 @@
 .grid-hour {
   display: block;
   box-sizing: border-box;
-  border-top: 1px solid #e7e7e7;
-  border-right: 1px solid #e7e7e7;
-  //position: relative;
+  border-top: 2px solid #e7e7e7;
+  border-right: 2px solid #e7e7e7;
 }
 
 .grid-day:last-of-type .grid-hour {
@@ -54,6 +53,7 @@
 
 schedule-event {
   display: block;
+  opacity: 1.0;
   box-sizing: border-box;
   border-top: 1px solid #e7e7e7!important; //temp fix for the borders not showing
   border-right: 1px solid #e7e7e7 !important;
@@ -70,3 +70,9 @@ schedule-event {
   margin-bottom: 15px;
 }
 
+.right-barrier {
+  height: 600px;
+  width: 20px;
+  left: 100%;
+  position: absolute;
+}

--- a/web/src/app/schedule-view/schedule/component.ts
+++ b/web/src/app/schedule-view/schedule/component.ts
@@ -4,6 +4,7 @@ import { ScheduleSet } from '../../models/schedule-set';
 import { Day } from '../../models/day.model';
 import { SelectionService } from '../../services/selection.service';
 import { ColorService } from '../../services/color.service';
+import { ScheduleEventComponent } from '../schedule-event/component';
 
 @Component({
   selector: 'schedule',
@@ -17,12 +18,28 @@ export class ScheduleComponent implements AfterViewInit {
   @Input() scheduleSet: ScheduleSet;
   @ViewChild('mySchedule')
   public mySchedule: ElementRef
+  @ViewChild('schedule_event')
+  public schedEvent: ElementRef;
+  @ViewChild(ScheduleEventComponent)
+  public schedEventComponent: ScheduleEventComponent;
   public scheduleNode;
+  public currentPeriod = null;
+  public currentBlockColor = null;
 
   constructor (private colorService: ColorService) { }
 
   ngAfterViewInit() {
     this.scheduleNode = this.mySchedule.nativeElement;
+  }
+
+  public mouseEnter (period: Period): void {
+    this.currentPeriod = period;
+    this.currentBlockColor = this.getBackgroundColor(period);
+  }
+  
+  public mouseLeft (): void {
+    this.currentPeriod = null;
+    this.currentBlockColor = null;
   }
 
   public get schedule (): Schedule {
@@ -72,7 +89,32 @@ export class ScheduleComponent implements AfterViewInit {
 
   public eventHeight (period: Period): number {
     const eventDuration = this.toMinutes(period.end) - this.toMinutes(period.start);
-    return (this.scheduleSet.height  * (eventDuration / this.scheduleSet.numMinutes));
+    var scheduleEventHeight = (this.scheduleSet.height  * (eventDuration / this.scheduleSet.numMinutes))
+    if (period == this.currentPeriod) {
+      var professorNamesLength = period.section.instructors.join(', ').length;
+      if (scheduleEventHeight < 87) {
+        if (professorNamesLength > 22) {
+          return 87;
+        } else if (professorNamesLength < 22 && scheduleEventHeight < 68) {
+          return 68;
+        } 
+      }
+    }
+    return scheduleEventHeight;
+  }
+
+  public setZIndex (period: Period): number {
+    if (period == this.currentPeriod) {
+      return 1;
+    }
+  }
+
+  public lowerOpacity(period: Period): number {
+    if (this.currentBlockColor == this.getBackgroundColor(period) || !this.currentBlockColor) {
+      return 1;
+    } else {
+      return 0.5;
+    }
   }
 
   public getBackgroundColor (period: Period) {


### PR DESCRIPTION
![scheduleHover](https://user-images.githubusercontent.com/49923986/62721380-10f4d280-b9da-11e9-9cf4-02a7144fffa6.png)
![scheduleNoHover](https://user-images.githubusercontent.com/49923986/62721387-15b98680-b9da-11e9-83ca-b3dbf8a4ee18.png)

First image is cursor hovering over a course block. A block expands only if the cursor is hovering over it, so other blocks from the same course do not expand (but the opacities remain the same).

I added a div on the right side of the schedule grid because a mouseleave event on the element with class "schedule" does not cover the right side for some reason.

A course block expands based on its height and the length of the list of professors (to check if it overflows to two lines).