### PR TITLE
Improve Docker config. for web service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 
 # dependencies
 **/node_modules
+**/npm-cache
 
 # IDEs and editors
 /.idea

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -38,7 +38,9 @@ services:
       - "4200:4200"
     volumes:
       - "./web/src:/usr/src/app/src"
-    command: "ng build --watch"
+      - "./web/npm-cache:/root/.npm"
+      - "./web/node_modules:/usr/src/app/node_modules"
+    command: "npm run-script docker-install-build"
 
   malg:
     build: ./malg

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 dist-web
+npm-cache

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -6,11 +6,21 @@ RUN mkdir -p $APP_DIR/bin
 RUN mkdir -p $APP_DIR/src
 WORKDIR $APP_DIR
 
-RUN npm install -g @angular/cli@6.1.3 --silent --depth 1
+RUN npm cache clean --force && npm config set package-lock false
+RUN npm install @angular/cli@6.1.3 -g --verbose
 COPY package.json $APP_DIR
-RUN npm install --silent --depth 0
+
+# npm packages are installed at runtime, not buildtime.
+# this is done because volumes are not accessible during image building.
+# node_modules and npm-cache are available at runtime, so running
+# npm install every time the container is started is still efficient.
 
 COPY angular.json karma.conf.js protractor.conf.js tsconfig.json tslint.json $APP_DIR
 COPY ./src $APP_DIR
 
-VOLUME /usr/src/app/dist-web
+# You don't want to declare volumes inside Dockerfiles. The necessary volumes are already declared via. docker-compose.yml.
+# https://boxboat.com/2017/01/23/volumes-and-dockerfiles-dont-mix/
+
+# VOLUME /usr/src/app/dist-web
+# VOLUME /usr/src/app/node_modules
+# VOLUME /root/.npm

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "docker-install-build": "npm install && ng build --watch"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
* Commands related to the web container are altered such that npm install is run on every startup. This means that the image and node_modules are completely separated.
* Updating package.json still requires a partial image rebuild, but it is much faster.
* Volumes are used to cache node_modules between containers.
* I don't see any need to add ```VOLUME``` statements to the Dockerfile. All the volumes are already defined in ```docker-compose.yml```.